### PR TITLE
nav social icons light theme fix & detect preferred theme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /node_modules
 /.pnp
 .pnp.js
+package-lock.json
 
 # testing
 /coverage

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.
+// see https://nextjs.org/docs/pages/building-your-application/configuring/typescript for more information.

--- a/package.json
+++ b/package.json
@@ -32,6 +32,6 @@
         "eslint-config-next": "14.2.3",
         "postcss": "^8.4.38",
         "tailwindcss": "^3.4.3",
-        "typescript": "4.4.2"
+        "typescript": "4.5.2"
     }
 }

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -84,28 +84,28 @@ const Nav = () => {
                         title="GitHub"
                         href={"https://github.com/cnrad"}
                         icon={
-                            <SiGithub className="w-6 h-6 cursor-pointer hover:fill-white fill-gray-400 transition-colors" />
+                            <SiGithub className="w-6 h-6 cursor-pointer hover:fill-[#12181d] dark:hover:fill-white fill-gray-400 transition-colors" />
                         }
                     />
                     <LinkButton
                         title="Twitter"
                         href={"https://twitter.com/notcnrad"}
                         icon={
-                            <SiTwitter className="w-6 h-6 cursor-pointer hover:fill-white fill-gray-400 transition-colors" />
+                            <SiTwitter className="w-6 h-6 cursor-pointer hover:fill-[#12181d] dark:hover:fill-white fill-gray-400 transition-colors" />
                         }
                     />
                     <LinkButton
                         title="LinkedIn"
                         href={"https://linkedin.com/in/cnrad"}
                         icon={
-                            <SiLinkedin className="w-6 h-6 cursor-pointer hover:fill-white fill-gray-400 transition-colors" />
+                            <SiLinkedin className="w-6 h-6 cursor-pointer hover:fill-[#12181d] dark:hover:fill-white fill-gray-400 transition-colors" />
                         }
                     />
                     <LinkButton
                         title="Email"
                         href={"mailto:hello@cnrad.dev"}
                         icon={
-                            <FiMail className="w-6 h-6 cursor-pointer hover:stroke-white stroke-gray-400 transition-colors" />
+                            <FiMail className="w-6 h-6 cursor-pointer hover:stroke-[#12181d] dark:hover:stroke-white stroke-gray-400 transition-colors" />
                         }
                     />
                 </div>

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -8,7 +8,10 @@ const ThemeToggle = () => {
         let storedTheme = localStorage.getItem("theme") as string;
 
         if (!storedTheme) {
-            localStorage.setItem("theme", theme);
+            localStorage.setItem(
+                "theme",
+                window.matchMedia("(prefers-color-scheme: light)").matches ? "light" : "dark"
+            );
         } else {
             setTheme(storedTheme);
             storedTheme === "light" ? document.querySelector("html")?.classList.remove("dark") : null;


### PR DESCRIPTION
## nav social icons light theme fix

```tsx
<SiIcon className="w-6 h-6 cursor-pointer hover:fill-[#12181d] dark:hover:fill-white fill-gray-400 transition-colors" />
```
> The social icons in ```Nav.tsx``` were missing themed  ```hover:fill```'s. I made the light theme hover color the same as the ToggleTheme button (```#12181d```).

![icon_hover](https://github.com/user-attachments/assets/08452966-c437-41b9-9ca0-e1c436e41127)

## detect preferred theme

```tsx
if (!storedTheme) {
    localStorage.setItem(
        "theme",
        window.matchMedia("(prefers-color-scheme: light)").matches ? "light" : "dark"
    );
} else { ...
```
> now detects preferred theme when first storing theme instead of automatically assigning it to dark. leans towards dark theme if incompatible (https://caniuse.com/?search=prefers-color-scheme).

![detect_theme](https://github.com/user-attachments/assets/2ab8e199-33e1-48f2-92b6-c010691ea9b1)

> [!NOTE]
>
> Also updated typescript dependency to next.js minimum recommended (```typescript v4.2.5```).
